### PR TITLE
Add functionality to easily change max time-out on the app page

### DIFF
--- a/apps/conda-forger/README.md
+++ b/apps/conda-forger/README.md
@@ -8,3 +8,5 @@
 [#streamlit-conda-forger-app]: https://share.streamlit.io/sugatoray/streamlit_apps/master/apps/conda-forger/app.py
 [#code-conda-forger-app]: https://github.com/sugatoray/streamlit_apps/blob/master/apps/conda-forger/app.py
 <!--- Define Links: End --->
+
+👉 Use `ST_MAX_TIME_OUT` environment variable to change the max timeout for the app, from the app page.

--- a/apps/conda-forger/app.py
+++ b/apps/conda-forger/app.py
@@ -33,7 +33,7 @@ options = A.make_sidebar(recipes_dir=recipes_dir)
 
 st.info(f"""### Tip 💡
     If the recipe generation fails, you may want to try with 
-    a higher timeout (> {options.get("timeout")} seconds).
+    a higher timeout (`>{options.get("timeout")},<={A.MAX_TIME_OUT}` seconds).
     """)
 
 IS_PYPI = options.get("source", Defaults.DEFAULT_PACKAGE_SOURCE).lower() == "pypi"

--- a/apps/conda-forger/app.py
+++ b/apps/conda-forger/app.py
@@ -23,7 +23,12 @@ st.write(dedent("""
     """))
 
 with st.expander("Instruction: How to create a conda-forge package", expanded=False):
-    st.write(dedent(open(os.path.join(Defaults.APP_DIR, "instruction.md")).read().replace("# Instruction", "").replace("# ", "### ")))
+    st.write(dedent(open(os.path.join(Defaults.APP_DIR, "instruction.md"))
+                        .read()
+                        .replace("# Instruction", "")
+                        .replace("# ", "### ")
+                    )
+            )
 
 if options.get("debug-mode", False):
     st.write("**Recipes Directory:**")

--- a/apps/conda-forger/app.py
+++ b/apps/conda-forger/app.py
@@ -31,6 +31,11 @@ if options.get("debug-mode", False):
 
 options = A.make_sidebar(recipes_dir=recipes_dir)
 
+st.info(f"""### Tip 💡
+    If the recipe generation fails, you may want to try with 
+    a higher timeout (> {options.get("timeout")} seconds).
+    """)
+
 IS_PYPI = options.get("source", Defaults.DEFAULT_PACKAGE_SOURCE).lower() == "pypi"
 IS_GITHUB = options.get("source", Defaults.DEFAULT_PACKAGE_SOURCE).lower() == "github"
 

--- a/apps/conda-forger/components/appfactory.py
+++ b/apps/conda-forger/components/appfactory.py
@@ -36,7 +36,7 @@ def make_sidebar(recipes_dir: Optional[str]=None):
         options["timeout"] = st.number_input(
             label="Timeout (in seconds)",
             min_value=10,
-            max_value=40,
+            max_value=os.environ.get("APP_MAX_TIME_OUT", Defaults.MAX_TIME_OUT)
             value=Defaults.TIME_OUT,
             step=5,
         )

--- a/apps/conda-forger/components/appfactory.py
+++ b/apps/conda-forger/components/appfactory.py
@@ -36,7 +36,7 @@ def make_sidebar(recipes_dir: Optional[str]=None):
         options["timeout"] = st.number_input(
             label="Timeout (in seconds)",
             min_value=10,
-            max_value=os.environ.get("APP_MAX_TIME_OUT", Defaults.MAX_TIME_OUT)
+            max_value=int(os.environ.get("ST_MAX_TIME_OUT", Defaults.MAX_TIME_OUT)),
             value=Defaults.TIME_OUT,
             step=5,
         )

--- a/apps/conda-forger/components/appfactory.py
+++ b/apps/conda-forger/components/appfactory.py
@@ -8,6 +8,13 @@ from components import utils as U
 
 Defaults = U.Defaults
 
+try:
+    MAX_TIME_OUT = int(os.environ.get("ST_MAX_TIME_OUT", Defaults.MAX_TIME_OUT))
+except ValueError as e:
+    MAX_TIME_OUT = Defaults.MAX_TIME_OUT
+    os.environ["ST_MAX_TIME_OUT"] = MAX_TIME_OUT
+
+
 def make_sidebar(recipes_dir: Optional[str]=None):
     if recipes_dir is None:
         recipes_dir = os.environ.get("RECIPES_DIR")
@@ -33,10 +40,11 @@ def make_sidebar(recipes_dir: Optional[str]=None):
         if options["clearall"]:
             U.clearall(recipes_dir=recipes_dir) # type: ignore
 
+
         options["timeout"] = st.number_input(
             label="Timeout (in seconds)",
             min_value=10,
-            max_value=int(os.environ.get("ST_MAX_TIME_OUT", Defaults.MAX_TIME_OUT)),
+            max_value=MAX_TIME_OUT,
             value=Defaults.TIME_OUT,
             step=5,
         )

--- a/apps/conda-forger/components/utils.py
+++ b/apps/conda-forger/components/utils.py
@@ -27,6 +27,7 @@ class Defaults:
     DEFAULT_PACKAGE_SOURCE: str = "PyPI"
     DEFAULT_RECIPES_DIR: str = ".scrap"
     TIME_OUT: int = 20
+    MAX_TIME_OUT: int = 60
     APP_DIR: str = os.environ.get("ST_APP_DIR", os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
     APP_URL: str = r"https://share.streamlit.io/sugatoray/streamlit_apps/master/apps/conda-forger/app.py"
     APP_URL_SHORT: str = r"https://tinyurl.com/conda-forger"


### PR DESCRIPTION
Currently the max time-out is set to a hard coded `40` seconds. This PR will change that and allow one to control the max timeout via an environment variable: `ST_MAX_TIME_OUT`.