### PR TITLE
Adding functionality to create recipe from github repo

### DIFF
--- a/apps/conda-forger/app.py
+++ b/apps/conda-forger/app.py
@@ -6,56 +6,63 @@ from components import utils as U
 from components import appfactory as A
 
 Defaults = U.Defaults
-options = dict()
 
-os.environ["RECIPES_DIR"] = os.path.join(
-    Defaults.APP_DIR, Defaults.DEFAULT_RECIPES_DIR)
+def main():
+    options = dict()
 
-recipes_dir = U.create_recipes_dir(recipes_dir=None, app_dir=Defaults.APP_DIR)
+    os.environ["RECIPES_DIR"] = os.path.join(
+        Defaults.APP_DIR, Defaults.DEFAULT_RECIPES_DIR)
+
+    recipes_dir = U.create_recipes_dir(recipes_dir=None, app_dir=Defaults.APP_DIR)
 
 
-st.header("Conda Forger App :zap:")
+    st.header("Conda Forger App :zap:")
 
-st.write(dedent("""
-    This app helps you in creating **conda-forge** recipes.
+    st.write(dedent("""
+        This app helps you in creating **conda-forge** recipes.
 
-    > *Powered by* [**`grayskull`**](https://github.com/conda-incubator/grayskull) ❤️
-    """))
+        > *Powered by* [**`grayskull`**](https://github.com/conda-incubator/grayskull) ❤️
+        """))
 
-with st.expander("Instruction: How to create a conda-forge package", expanded=False):
-    st.write(dedent(open(os.path.join(Defaults.APP_DIR, "instruction.md"))
-                        .read()
-                        .replace("# Instruction", "")
-                        .replace("# ", "### ")
-                    )
-            )
+    with st.expander("Instruction: How to create a conda-forge package", expanded=False):
+        st.write(dedent(open(os.path.join(Defaults.APP_DIR, "instruction.md"))
+                            .read()
+                            .replace("# Instruction", "")
+                            .replace("# ", "### ")
+                        )
+                )
 
-if options.get("debug-mode", False):
-    st.write("**Recipes Directory:**")
-    st.code(os.environ.get("RECIPES_DIR"))
+    if options.get("debug-mode", False):
+        st.write("**Recipes Directory:**")
+        st.code(os.environ.get("RECIPES_DIR"))
 
-options = A.make_sidebar(recipes_dir=recipes_dir)
+    options = A.make_sidebar(recipes_dir=recipes_dir)
 
-st.info(f"""### Tip 💡
-    If the recipe generation fails, you may want to try with 
-    a higher timeout (`>{options.get("timeout")},<={A.MAX_TIME_OUT}` seconds).
-    """)
+    st.info(dedent(f"""### Tip 💡
+        If the recipe generation fails, you may want to try with 
+        a higher timeout (`>{options.get("timeout")},<={A.MAX_TIME_OUT}` seconds).
+        """))
 
-IS_PYPI = options.get("source", Defaults.DEFAULT_PACKAGE_SOURCE).lower() == "pypi"
-IS_GITHUB = options.get("source", Defaults.DEFAULT_PACKAGE_SOURCE).lower() == "github"
+    IS_PYPI = U.source_pypi(options)
+    IS_GITHUB = U.source_github(options)
+    options["IS_PYPI"] = IS_PYPI
+    options["IS_GITHUB"] = IS_GITHUB
 
-if IS_PYPI:
+    if IS_PYPI or IS_GITHUB:
 
-    options, generate, clear_workspace = A.update_app_options(options, recipes_dir=recipes_dir)
-    with st.expander("Input Parameters 📥", expanded=False):
-        st.json(options)
+        options, generate, clear_workspace = A.update_app_options(options, recipes_dir=recipes_dir)
+        with st.expander("Input Parameters 📥", expanded=False):
+            st.json(options)
 
-    recipe = A.generate_pypi_recipe(
-        options,
-        generate=generate,
-        recipes_dir=recipes_dir,
-    )
+        recipe = A.generate_recipe(
+            options,
+            generate=generate,
+            recipes_dir=recipes_dir,
+        )
 
-if IS_GITHUB:
-    msg_params = dict(height=300, width=700, bgcolor="fa5043", textcolor="fff")
-    U.show_message("Not Yet Implemented!", **msg_params)
+    # if IS_GITHUB:
+    #     U.show_not_implemented_banner()
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/conda-forger/components/appfactory.py
+++ b/apps/conda-forger/components/appfactory.py
@@ -68,22 +68,46 @@ def make_sidebar(recipes_dir: Optional[str]=None):
 def update_app_options(options: Dict[str, Any], recipes_dir: Optional[str]=None):
     if recipes_dir is None:
         recipes_dir = os.environ.get('RECIPES_DIR')
-    col1, col2 = st.columns([3, 2])
-    with col1:
-        options["package_name"] = st.text_input(
-            label="PyPI Package Name 👇",
-            value="",
-            placeholder="Null",
-            help="displacement in meters",
-        )
 
-    with col2:
-        options["package_version"] = st.text_input(
-            label="PyPI Package Version 👇",
-            value="",
-            placeholder="Null",
-            help="displacement in meters",
-        )
+    IS_PYPI = U.source_is_pypi(options)
+    IS_GITHUB = U.source_is_github(options)    
+    
+    
+    if IS_PYPI:
+        col1, col2 = st.columns([3, 2])
+        with col1:
+            options["package_name"] = st.text_input(
+                label="PyPI Package Name 👇",
+                value="",
+                placeholder="Null",
+                help="Provide package name from PyPI",
+            )
+
+        with col2:
+            options["package_version"] = st.text_input(
+                label="PyPI Package Version 👇",
+                value="",
+                placeholder="Null",
+                help="Optionally, specify package version from PyPI",
+            )
+    
+    elif IS_GITHUB:
+        col1, col2 = st.columns([5, 2])
+        with col1:
+            options["github_repo_url"] = st.text_input(
+                label="GitHub Repository URL 👇",
+                value="",
+                placeholder="https://github.com/{{ OWNER }}/{{ REPOSITORY }}",
+                help="Provide GitHub package repository url",
+            )
+
+        with col2:
+            options["github_release_tag"] = st.text_input(
+                label="GitHub Release Tag 👇",
+                value="",
+                placeholder="Null",
+                help="Optionally, provide the GitHub release tag from the repository.",
+            )
 
     _, col22, _, col24, _ = st.columns([2, 2, 1, 2, 2])
     with col22:
@@ -95,16 +119,45 @@ def update_app_options(options: Dict[str, Any], recipes_dir: Optional[str]=None)
     return options, generate, clear_workspace
 
 
-def generate_pypi_recipe(options: Dict[str, Any], generate: bool = False, recipes_dir: Optional[str] = None):
+def generate_recipe(options: Dict[str, Any], generate: bool = False, recipes_dir: Optional[str] = None):
     if recipes_dir is None:
         recipes_dir = os.environ.get('RECIPES_DIR')
-    package_name = options.get("package_name", None).strip()
-    package_version = options.get("package_version", None).strip()
-    if not package_version or package_version is None:
-        package_version = ""
-    if package_name and package_name is not None:
-        command = U.create_command(
-            package_name, options, package_version=package_version)
+    
+    IS_PYPI = U.source_is_pypi(options)
+    IS_GITHUB = U.source_is_github(options)
+
+    package_name: str = ""
+    package_version: str = ""
+    github_repo_url: str = ""
+    github_release_tag: str = ""
+    command: str = ""
+
+    if IS_PYPI:
+        package_name = options.get("package_name", None).strip()
+        package_version = options.get("package_version", None).strip()
+
+        if not package_version or package_version is None:
+            package_version = ""
+        if package_name and package_name is not None:
+            command = U.create_command(options, 
+                package_name = package_name, 
+                package_version = package_version
+            )
+    
+    elif IS_GITHUB:
+        github_repo_url = options.get("github_repo_url", None).strip()
+        github_release_tag = options.get("github_release_tag", None).strip()
+
+        if not github_release_tag or github_release_tag is None:
+            github_release_tag = ""
+        if github_repo_url and github_repo_url is not None:
+            command = U.create_command(options, 
+                github_repo_url = github_repo_url,
+                github_release_tag = github_release_tag
+            )
+            package_name = U.parse_github_url(url).get("repo", U.dummy_package_name())
+    
+    if command and package_name:
         st.info("### Command 🍎")
         if Defaults.USE_DEBUG_MODE or options.get("debug-mode", False):
             st.code(command, language="sh")

--- a/apps/conda-forger/components/appfactory.py
+++ b/apps/conda-forger/components/appfactory.py
@@ -176,9 +176,14 @@ def generate_recipe(options: Dict[str, Any], generate: bool = False, recipes_dir
                         return recipe
 
                 except subprocess.CalledProcessError as e:
-                    st.error(dedent(f"""### CalledProcessError
 
-                    {e}
+                    msg_params = dict(height=300, width=700, bgcolor="fa5043", textcolor="fff")
+                    U.show_message("Bad Request!", **msg_params)
 
-                    """))
-                    return None
+                    with st.expander("See Error Details ⛔", expanded=False):
+                        st.error(dedent(f"""### CalledProcessError
+
+                        {e}
+
+                        """))
+                        return None

--- a/apps/conda-forger/components/utils.py
+++ b/apps/conda-forger/components/utils.py
@@ -37,7 +37,7 @@ class Defaults:
     USE_DEBUG_MODE: bool = use_debug_mode()
 
 
-def create_recipes_dir(recipes_dir: Optional[str] = None, app_dir: Optional[str] = None):
+def create_recipes_dir(recipes_dir: Optional[str] = None, app_dir: Optional[str] = None) -> str:
     if recipes_dir is None:
         recipes_dir = Defaults.DEFAULT_RECIPES_DIR
     if app_dir is None:
@@ -71,12 +71,12 @@ def create_command(options: Dict[str, Any],
         return command
 
     elif IS_GITHUB:
-        release_tag = f' --tag {github_release_tag}' if github_release_tag else ''
-        command = f'grayskull pypi {github_repo_url}{release_tag}{strict_conda_forge} -o {recipes_dir} --maintainers ADD_YOUR_GITHUB_ID_HERE'
+        release_tag = f' --tag "{github_release_tag}"' if github_release_tag else ''
+        command = f'grayskull pypi "{github_repo_url}"{release_tag}{strict_conda_forge} -o {recipes_dir} --maintainers ADD_YOUR_GITHUB_ID_HERE'
         return command
 
 
-def show_recipe(package_name: str, recipes_dir: str = None):
+def show_recipe(package_name: str, recipes_dir: str = None) -> str:
     if recipes_dir is None:
         recipes_dir = os.environ.get('RECIPES_DIR')
     st.success("### Recipe 🎁")
@@ -89,7 +89,7 @@ def show_recipe(package_name: str, recipes_dir: str = None):
     return recipe
 
 
-def clearall(recipes_dir: str = None):
+def clearall(recipes_dir: str = None) -> None:
     if recipes_dir is None:
         recipes_dir = os.environ.get('RECIPES_DIR')
     if os.path.isdir(recipes_dir):
@@ -120,7 +120,7 @@ def add_about_section():
 
 
 @st.cache
-def generate_message_as_image(message: str, height: int = 600, width: int = 1200, bgcolor: str = "0288d1", textcolor: str = "fff"):
+def generate_message_as_image(message: str, height: int = 600, width: int = 1200, bgcolor: str = "0288d1", textcolor: str = "fff") -> str:
     import urllib
     message = urllib.parse.quote_plus(message)
     image_url = f"https://fakeimg.pl/{width}x{height}/{bgcolor}/{textcolor}/?text={message}"

--- a/apps/conda-forger/requirements.txt
+++ b/apps/conda-forger/requirements.txt
@@ -1,4 +1,4 @@
 streamlit>=1.4.0
-grayskull>=0.9.1
+grayskull>=1.4.1
 parse>=1.19.0
 faker>=13.15.1

--- a/apps/conda-forger/requirements.txt
+++ b/apps/conda-forger/requirements.txt
@@ -1,2 +1,4 @@
 streamlit>=1.4.0
 grayskull>=0.9.1
+parse>=1.19.0
+faker>=13.15.1


### PR DESCRIPTION
:fire: New feature: since grayskull version `1.4.1` release on 21-Jul-2022, the `grayskull` utility can be used with GitHub releases and tags as well. 

:point_right: This update of Conda-Forger app introduces the functionality to create recipes from GitHub releases (optionally, with release tags).

**Example:**

```sh
# without tag (uses latest release)
grayskull pypi https://github.com/sugatoray/genespeak

# with tag
grayskull pypi https://github.com/sugatoray/genespeak --tag v0.0.8
```

### Grayskull

- Repo: https://pypi.org/project/grayskull/
- Issue: https://github.com/conda-incubator/grayskull/issues/320
- PR: https://github.com/conda-incubator/grayskull/pull/346